### PR TITLE
Add Battery Discrete IO States

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,15 @@ Note: The old and legacy API states (API port 3480/7979) are currently not or on
     |string|R|
 
    *Read-only JSON string, which contains inverter information of your battery.*
-   
+
+* info.ios
+
+    |Data type|Permission|
+    |:---:|:---:|
+    |string|R|
+
+   *Read-only JSON string, which contains discrete IO information of your battery.*
+
 #### Channel: status
    
 * status.consumption
@@ -290,6 +298,9 @@ The both channels have the identical states. All states are read-only numbers.
 
 ### Channel: inverter
 The channel consists of read-only states of type `number`, providing information about the inverter of your battery.
+
+### Channel: ios
+The channel consists of read-only states of type `boolean`, providing information about the discrete IO states of your battery.
 
 ## Changelog
 <!--

--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -133,7 +133,15 @@ Hinweis: Die States der Legacy API (Port 3480) und der alten API (Port 7979) sin
     |string|R|
 
    *Nur lesbarer JSON String, mit Wechselrichter Informationen der sonnenBatterie.*
-   
+
+* info.ios
+
+    |Data type|Permission|
+    |:---:|:---:|
+    |string|R|
+
+   *Nur lesbarer JSON String, mit discrete IO Informationen der sonnenBatterie.*
+
 #### Channel: status
    
 * status.consumption
@@ -339,3 +347,6 @@ Die beiden Kanäle haben die identischen Zustände. Alle Zustände sind schreibg
 
 ### Channel: inverter
 Der Kanal besteht aus schreibgeschützten Zuständen vom Typ `number`, die Informationen über den Wechselrichter der sonnenBatterie liefern.
+
+### Channel: ios
+Der Kanal besteht aus schreibgeschützten Zuständen vom Typ `boolean`, die Informationen über die discrete IO Status der sonnenBatterie liefern.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -256,6 +256,19 @@ const newAPIStates = [
         native: {}
     },
     {
+        _id: `info.ios`,
+        type: `state`,
+        common: {
+            name: `Battery Discrete IO Information`,
+            type: `string`,
+            role: `json`,
+            read: true,
+            write: false,
+            desc: `Discrete IO information of your sonnen battery as JSON`
+        },
+        native: {}
+    },
+    {
         _id: `info.inverter`,
         type: `state`,
         common: {
@@ -286,6 +299,53 @@ const newAPIStates = [
         type: `channel`,
         common: {
             name: `Powermeter Information`
+        },
+        native: {}
+    },
+    {
+        _id: `ios`,
+        type: `channel`,
+        common: {
+            name: `Discrete IO Information`
+        },
+        native: {}
+    },
+    {
+        _id: `ios.DO_12`,
+        type: `state`,
+        common: {
+            name: `Self Consumption Relay`,
+            type: `boolean`,
+            role: `status`,
+            read: true,
+            write: false,
+            desc: `Self Consumption Relay Status`,
+        },
+        native: {}
+    },
+    {
+        _id: `ios.DO_13`,
+        type: `state`,
+        common: {
+            name: `PV Reduction 1`,
+            type: `boolean`,
+            role: `status`,
+            read: true,
+            write: false,
+            desc: `PV Reduction 1 Status`,
+        },
+        native: {}
+    },
+    {
+        _id: `ios.DO_14`,
+        type: `state`,
+        common: {
+            name: `PV Reduction 2`,
+            type: `boolean`,
+            role: `status`,
+            read: true,
+            write: false,
+            desc: `PV Reduction 2 Status`,
         },
         native: {}
     },


### PR DESCRIPTION
Add battery discrete IO states from sonnen API endpoint: `http://<ip>:8080/api/ios`.

* Full JSON string is available under `info.ios`
* Some relevant discrete IOs, including self consumption relay and pv reduction states are available under `ios.DO12`, `ios.DO13` and `ios.DO14`
